### PR TITLE
Fix issue 304: Waypoint numbers should start at 0 not 1 on map.

### DIFF
--- a/client/src/components/waypointmarker/WaypointMarker.tsx
+++ b/client/src/components/waypointmarker/WaypointMarker.tsx
@@ -60,7 +60,7 @@ const WaypointMarker = (props: WaypointMarkerProps) => {
   useEffect(() => {
     const waypoint = props.waypoint;
     marker.current?.setTooltipContent(
-      `${props.number} ${waypoint.name}<br />` +
+      `${props.number-1} ${waypoint.name}<br />` +
         `${waypoint.altitude_ft.toFixed()} ft ${waypoint.altitude_reference}<br />` +
         waypoint.timing
     );


### PR DESCRIPTION
Second try to fix the waypoint issue. This time the change only modifies what is displayed on the map, not the underlying index of the component. Dragging the waypoint now correctly retains the index.